### PR TITLE
Parallelize gradient calculation

### DIFF
--- a/inc/ica_supergaussian_reg.m
+++ b/inc/ica_supergaussian_reg.m
@@ -1,6 +1,8 @@
 function [ S, W ] = ica_supergaussian_reg( X, Y, lambda, alpha )
 %ICA_SUPERGAUSSIAN_REG ICA with sparse regression regularization
 %   X and Y should be pre-whitened
+% Gradient calculation is parallelized over features with parfor
+% and will use matlabpool if available
 
 % verbosity flag
 verbose = false;
@@ -80,7 +82,7 @@ WY = W*Y;
 f = 0;
 dW = zeros(p);
 
-for k = 1:p
+parfor k = 1:p
     
     w = W(k,:)';
     wX = WX(k,:);


### PR DESCRIPTION
In an attempt to speed up the algorithm I've tried to parallelize the gradient calculation (over features). A simple change from `for` to `parfor` seems to have done the trick and worked in my tests, unless there's something silly I'm overlooking. 

In order for this to make any difference, a user must first open a pool of matlab workers using `matlabpool open N` where N is the number of workers required. Otherwise parfor seems to just fallback as a for on a single worker.
